### PR TITLE
lowercase the command input for comparison

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ async fn main() -> Result<()> {
 }
 
 async fn handle_user_message(state: AsyncState, message: Message) -> Result<UserResponse> {
-    Ok(match message.content.as_ref() {
+    Ok(match message.content.to_lowercase().as_ref() {
         "!help" | "!bot" => {
             info!("user: received `help` command");
             UserResponse::Help

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,7 +146,7 @@ async fn handle_admin_message(state: AsyncState, content: String) -> Result<Admi
 
     Ok(
         match (
-            command,
+            command.to_lowercase().as_ref(),
             parts.next(),
             parts.next(),
             parts.next(),


### PR DESCRIPTION
Suggest to lowercase the incoming command to lowercase so that, for example, !HELP, !help, !Help, ad so forth will all trigger the intended command. Noticed people doing !Discord and getting no response in chat until they did !discord.